### PR TITLE
[Chore] Remove prod.secret.exs config import to allow deployment

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -50,5 +50,3 @@ config :logger, level: :info
 # Check `Plug.SSL` for all available options in `force_ssl`.
 config :google_search_data_viewer, GoogleSearchDataViewerWeb.Endpoint,
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
-
-import_config "prod.secret.exs"


### PR DESCRIPTION
## What happened 👀

Deleted the import statement because automatic deployment fails due to "prod.secret.exs" file failing to exist since it was removed in a previous PR

<img width="774" alt="Screenshot 2565-05-19 at 10 56 44" src="https://user-images.githubusercontent.com/8955671/169201258-86b96429-2cae-4dc5-b316-419f4a3b385a.png">

